### PR TITLE
Add whitelist mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,10 +48,14 @@ fn main() {
             template,
             tag,
             config: context,
+            whitelist_mode,
         } => {
             let mut vault_builder = VaultBuilder::new(&vault);
             if let Some(tags) = tag {
                 vault_builder.filter_tags(tags);
+            }
+            if whitelist_mode {
+                vault_builder.whitelist_mode();
             }
 
             let vault = vault_builder.build();
@@ -159,6 +163,10 @@ enum Commands {
         /// Only select notes with this tag (can be used multiple times).
         #[arg(short, long)]
         tag: Option<Vec<String>>,
+
+        /// Only publish notes that have the `publish: true` metadata.
+        #[arg(long)]
+        whitelist_mode: bool,
 
         #[arg(long, default_value = ".garden/site.yaml")]
         config: String,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -27,6 +27,10 @@ impl Metadata {
 
         tags
     }
+
+    pub fn get(&self, key: &str) -> Option<&MetadataValue> {
+        self.inner.get(key)
+    }
 }
 
 impl From<HashMap<String, MetadataValue>> for Metadata {

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -61,17 +61,14 @@ impl VaultBuilder {
                                     }
                                 }
 
-                                if self.whitelist_mode {
-                                    let publish = note.metadata.get("publish");
-                                    match publish {
-                                        Some(publish) => {
-                                            if let MetadataValue::Boolean(publish) = publish {
-                                                if !publish {
-                                                    continue;
-                                                }
-                                            }
-                                        }
-                                        None => continue,
+                                                                if self.whitelist_mode {
+                                    let publish = note
+                                        .metadata
+                                        .get("publish")
+                                        .map_or(Some(false), |value| value.as_bool())
+                                        .unwrap_or(false);
+                                    if !publish {
+                                        continue;
                                     }
                                 }
 

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -7,11 +7,12 @@ use std::{
 };
 use walkdir::WalkDir;
 
-use crate::note::Note;
+use crate::{note::Note, metadata::MetadataValue};
 
 pub(crate) struct VaultBuilder {
     pub directory: PathBuf,
     tags: Option<Vec<String>>,
+    whitelist_mode: bool,
 }
 
 impl VaultBuilder {
@@ -19,6 +20,7 @@ impl VaultBuilder {
         Self {
             directory: directory.as_ref().to_path_buf(),
             tags: None,
+            whitelist_mode: false,
         }
     }
 
@@ -58,6 +60,21 @@ impl VaultBuilder {
                                         continue;
                                     }
                                 }
+
+                                if self.whitelist_mode {
+                                    let publish = note.metadata.get("publish");
+                                    match publish {
+                                        Some(publish) => {
+                                            if let MetadataValue::Boolean(publish) = publish {
+                                                if !publish {
+                                                    continue;
+                                                }
+                                            }
+                                        }
+                                        None => continue,
+                                    }
+                                }
+
                                 let note_path = ItemPath::from_path_without_ext(relative_path);
                                 let index = graph.add_node(note_path.clone());
                                 notes.insert(note_path, NoteItem { index, note });
@@ -114,6 +131,11 @@ impl VaultBuilder {
 
     pub(crate) fn filter_tags(&mut self, tags: Vec<String>) -> &mut Self {
         self.tags = Some(tags);
+        self
+    }
+
+    pub(crate) fn whitelist_mode(&mut self) -> &mut Self {
+        self.whitelist_mode = true;
         self
     }
 }


### PR DESCRIPTION
In this pull request, I've implemented a whitelist approach for publishing the notes.

This approach introduces an optional metadata keyword, `publish`, to the note. If `publish: true` is present in the metadata of the note, it will be included in the published site, otherwise it will be excluded. This option is useful for drafts, private notes, or content that isn't ready or appropriate for the public yet.

The new changes include:
- Adding a `whitelist_mode` field in the `VaultBuilder` structure to represent this behavior.
- Adding a new flag, `whitelist_mode`, to the Command enum (which will be enabled with the argument `--whitelist-mode` on the command line).
- Adding a new method, `get`, on the `Metadata` structure.
- Enhancing the note parsing loop in the `VaultBuilder.build` function to check each note's metadata for `publish: true`.

These changes don't affect the default behavior of obsidian-garden, only adding new functionality.